### PR TITLE
Add row level security and improve documentation 

### DIFF
--- a/backend/rbac/check_permissions.py
+++ b/backend/rbac/check_permissions.py
@@ -284,6 +284,9 @@ def check_scope_privilages(
     column_scopes: list[ColumnScope] = [],
     alias_table_map: dict[str, str] = {},
 ) -> PrivilageCheckResult:
+    """
+    This function checks if the scopes for a given table is satisfied.
+    """
     select_query = reference_table.find_ancestor(exp.Select)
     assert select_query is not None
 
@@ -448,7 +451,7 @@ def check_query_privilages(
     ctes = parsed_query.find_all(exp.CTE)
     valid_query_aliases = allowed_aliases
     for cte in ctes:
-        cte_query = list(cte.find_all(exp.Select))[0]
+        cte_query = next(cte.find_all(exp.Select))
         cte_result = check_query_privilages(
             table_privilages_map, roles, role_id, cte_query.sql(), table_scopes
         )
@@ -470,7 +473,7 @@ def check_query_privilages(
     # Check each subquery in the subqueries
     subqueries = parsed_query.find_all(exp.Subquery)
     for subquery in subqueries:
-        select = list(subquery.find_all(exp.Select))[0]
+        select = next(subquery.find_all(exp.Select))
         subquery_result = check_query_privilages(
             table_privilages_map,
             roles,

--- a/backend/rbac/check_permissions.py
+++ b/backend/rbac/check_permissions.py
@@ -282,9 +282,20 @@ def check_scope_privilages(
             scoping_expresssions_by_column[column.name].append(operator)
 
     for column_scope in column_scopes:
-        scoping_expressions = scoping_expresssions_by_column[column_scope.column]
-        scope_matched = False
+        scoping_expressions = scoping_expresssions_by_column.get(column_scope.column)
 
+        if scoping_expressions is None:
+            return PrivilageCheckResult(
+                query_allowed=False,
+                err_code=ErrorCode.ROLE_NO_ROWS_ACCESS,
+                context={
+                    "reason": "No where clauses found for column in the query segment",
+                    "column": column_scope.column,
+                    "query_segment": select_query.sql(),
+                },
+            )
+
+        scope_matched = False
         for operator in scoping_expressions:
             column: exp.Column
             value: exp.Expression

--- a/backend/rbac/check_permissions.py
+++ b/backend/rbac/check_permissions.py
@@ -257,7 +257,7 @@ def check_scope_privilages(
             is_valid_table_name_for_column = (
                 column.table is not None and column.table != ""
             )
-            if is_valid_table_name_for_column:
+            if not is_valid_table_name_for_column:
                 return PrivilageCheckResult(
                     query_allowed=False,
                     err_code=ErrorCode.UNSUPPORTED_SQL_QUERY,

--- a/backend/rbac/test.py
+++ b/backend/rbac/test.py
@@ -2,7 +2,7 @@ from check_permissions import check_query_privilages, Role, RoleTablePrivileges
 import unittest
 
 
-class TestRBAC(unittest.TestCase):
+class TestColumnSecurity(unittest.TestCase):
 
     def setUp(self):
         self.roles = [
@@ -24,15 +24,13 @@ class TestRBAC(unittest.TestCase):
                     "admin",
                     "employees",
                     ["name", "salary", "department_id"],
-                    ["name"],
+                    [],
                 )
             ],
             "departments": [
+                RoleTablePrivileges("id2", "admin", "departments", ["name", "id"], []),
                 RoleTablePrivileges(
-                    "id2", "admin", "departments", ["name", "id"], ["name"]
-                ),
-                RoleTablePrivileges(
-                    "id2", "read_only_user", "departments", ["name"], ["name"]
+                    "id2", "read_only_user", "departments", ["name"], []
                 ),
             ],
         }

--- a/backend/rbac/test.py
+++ b/backend/rbac/test.py
@@ -398,6 +398,94 @@ class TestRowSecurity(unittest.TestCase):
         )
         self.assertTrue(result.query_allowed)
 
+    def test_scope_value_is_string_satisfied(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id = '1'",
+            {
+                "projects": [ColumnScope("projects", "id", "1", value_type="string")],
+            },
+        )
+        self.assertTrue(result.query_allowed)
+
+    def test_scope_value_is_string_not_satisfied(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id = '1'",
+            {
+                "projects": [ColumnScope("projects", "id", "2", value_type="string")],
+            },
+        )
+        self.assertFalse(result.query_allowed)
+
+    def test_scope_value_is_string_invalid(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id = 1",
+            {
+                "projects": [ColumnScope("projects", "id", "1", value_type="string")],
+            },
+        )
+        self.assertFalse(result.query_allowed)
+
+    def test_scope_in_operator_satisfied(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id IN (1, 2)",
+            {
+                "projects": [
+                    ColumnScope(
+                        "projects", "id", ["1", "2"], operator="IN", value_type="list"
+                    )
+                ],
+            },
+        )
+        self.assertTrue(result.query_allowed)
+
+    def test_scope_not_in_operator_satisfied(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id NOT IN (1, 2)",
+            {
+                "projects": [
+                    ColumnScope(
+                        "projects", "id", ["1", "2"], operator="NOT IN", value_type="list"
+                    )
+                ],
+            },
+        )
+        self.assertTrue(result.query_allowed)
+
+    def test_scope_is_null_satisfied(self):
+        result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id IS NULL",
+            {"projects": [ColumnScope("projects", "id", None, "IS", "null")]},
+        )
+        self.assertTrue(result.query_allowed)
+
+    def test_scope_is_not_null_satisfied(self):
+        unittest.result = check_query_privilages(
+            self.table_privilages_map,
+            self.roles,
+            "project_manager",
+            "SELECT p.id, p.name FROM projects as p WHERE p.id IS NOT NULL",
+            {"projects": [ColumnScope("projects", "id", None, "IS NOT", "null")]},
+        )
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/rbac/test.py
+++ b/backend/rbac/test.py
@@ -124,7 +124,6 @@ class TestColumnSecurity(unittest.TestCase):
             SELECT employee_departments.name, employee_departments.department FROM employee_departments
             """,
         )
-        print(result)
         self.assertTrue(result.query_allowed)
 
     def test_cte_query_no_table_access(self):
@@ -334,7 +333,6 @@ class TestRowSecurity(unittest.TestCase):
                 "projects": [ColumnScope("projects", "id", "1")],
             },
         )
-        print(result)
         self.assertTrue(result.query_allowed)
 
     def test_joined_table_scopes_not_satisfied(self):


### PR DESCRIPTION
This PR introduces row level security to the RBAC system.

This feature adds the following 
- Column Scopes: Roles can now specify which rows they can access for specific tables based on column values.
- Scope Definitions: Column scopes are defined using `ColumnScope` objects, which specify the table, column, operator, and value to use for filtering rows.
- Scope Validation: The `check_scope_privilages` function validates whether the SQL query's where clauses satisfy the defined column scopes for the tables involved.

Key Changes:
- Added `ColumnScope` to represent column scopes.
- Added `check_scope_privilages` function to validate column scopes.
- Modified `check_table_privilages_for_role` to return a `PrivilageCheckResult` with additional context about the check.
- Modified `check_query_privilages` to include column scopes and to validate them during the query check.
- Improved Documentation
- Removed `__init__` constructors for the classes and convert them into `dataclasses`

Example:
A role can now be defined with the following column scope:
```python
table_scopes = {
    "projects": [ColumnScope("projects", "id", "1")],
}
```
    
This means that the role can only access rows in the projects table where the id column equals 1.

Closes #2 