### PR TITLE
fix: closed all stale db sessions, restrict EXTERNAL_COORDINATOR

### DIFF
--- a/backend/controllers/sql_response.py
+++ b/backend/controllers/sql_response.py
@@ -132,6 +132,7 @@ async def do_nlq(
             session_id=str(session.session_id),
         )
 
+    db_session.close()
     logger.info("NLQ Completed")
 
 

--- a/backend/db/db_queries.py
+++ b/backend/db/db_queries.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import desc, asc
 from db.models import (
     ExecutionLog,
@@ -492,6 +492,11 @@ def get_exeuction_log_result(
     try:
         execution_result_with_log = (
             db_session.query(ExecutionLog, ExecutionResult)
+            .options(
+                joinedload(ExecutionLog.query),
+                joinedload(ExecutionLog.user),
+                joinedload(ExecutionResult.execution_log),
+            )
             .outerjoin(
                 ExecutionResult,
                 ExecutionLog.id == ExecutionResult.execution_id,

--- a/backend/queues/tasks.py
+++ b/backend/queues/tasks.py
@@ -85,6 +85,7 @@ class ExecuteQueryOp(celery.Task):
 
         if self._db_session is not None:
             self._db_session.close()
+            self._db_session = None
 
 
 @app.task(base=ExecuteQueryOp, bind=True)

--- a/backend/rbac/check_permissions.py
+++ b/backend/rbac/check_permissions.py
@@ -588,7 +588,7 @@ def check_query_privilages(
         if table_name in valid_query_aliases:
             continue
 
-        if table_name not in table_privilages_for_role:
+        if table_name not in table_privilages_for_role or active_role == "EXTERNAL_COORDINATOR":
             return PrivilageCheckResult(
                 query_allowed=False,
                 err_code=ErrorCode.ROLE_NO_TABLE_ACCESS,

--- a/backend/roles.schema.json
+++ b/backend/roles.schema.json
@@ -1,4 +1,4 @@
 {
   "$id": "roles.schema.json",
-  "enum": ["SUPER_ADMIN", "ADMIN", "CLIENT", "PROJECT_MANAGER", "COORDINATOR"]
+  "enum": ["SUPER_ADMIN", "ADMIN", "CLIENT", "PROJECT_MANAGER", "COORDINATOR", "EXTERNAL_COORDINATOR"]
 }

--- a/backend/server.py
+++ b/backend/server.py
@@ -397,6 +397,8 @@ async def get_execution_result_for_id(
             f"Error while retrieving execution result for user: {user_info.user_id}. Error: {str(e)}"
         )
         raise HTTPException(status_code=500, detail="Failed to get execution result.")
+    finally:
+        db.close()
 
     if not response:
         raise HTTPException(status_code=404, detail="Execution log not found.")

--- a/backend/utils/query_pipeline.py
+++ b/backend/utils/query_pipeline.py
@@ -82,3 +82,4 @@ class QueryExecutionPipeline:
     def clean(self):
         if self._db_session is not None:
             self._db_session.close()
+            self._db_session = None

--- a/frontend/src/components/SavedQuery/index.tsx
+++ b/frontend/src/components/SavedQuery/index.tsx
@@ -136,7 +136,7 @@ const SavedQuery = ({
             </Text>
           </Box>
         )}
-        {savedQueryTableData.length > 0 && (
+        {savedQueryTableData.length >= 0 && (
           <Box w="100%" display="flex" gap={4}>
             <Button
               justifyContent={"space-between"}


### PR DESCRIPTION
Closed all stale db sessions. Added External Coordinator role which cannot access chat section. Execute button on saved queries is always visible now.