### PR TITLE
fix: remove last execution, errors ignore in converting to numeric

### DIFF
--- a/backend/utils/rows_to_json.py
+++ b/backend/utils/rows_to_json.py
@@ -20,7 +20,7 @@ def convert_rows_to_serializable(rows: Sequence[Row[Any]]) -> list[dict[str, Any
         df[column] = df[column].apply(to_json_serializable)
 
 
-    df = df.apply(pd.to_numeric, downcast='float')
+    df = df.apply(pd.to_numeric, downcast='float', errors='ignore')
     return df.to_dict(orient="records") #type:ignore
 
 

--- a/frontend/src/components/SavedQuery/index.tsx
+++ b/frontend/src/components/SavedQuery/index.tsx
@@ -199,15 +199,17 @@ const SavedQuery = ({
             </Text>
           </Box>
         )}
-        {lastExecutedAt && (
-          <Text fontSize="sm" color="gray.300" fontStyle="italic">
-            <strong>Last Updated At: </strong>
-            {new Date(lastExecutedAt).toLocaleString(undefined, {
-              dateStyle: "long",
-              timeStyle: "short",
-            })}
-          </Text>
-        )}
+        {
+          lastExecutedAt && (<span></span>)
+          //  <Text fontSize="sm" color="gray.300" fontStyle="italic">
+          //    <strong>Last Updated At: </strong>
+          //    {new Date(lastExecutedAt).toLocaleString(undefined, {
+          //      dateStyle: "long",
+          //      timeStyle: "short",
+          //    })}
+          //  </Text>
+          //)
+        }
         <Divider />
         {savedQueryData.description && (
           <Box w="100%">


### PR DESCRIPTION
Not showing Last executed time in Saved query.
Ignoring errors when converting row data to numeric (if data cannot be converted, it will remain the same).