### PR TITLE
feat: add column_order field in execution results

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import (
     relationship,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
-from executor.models import QueryResults
+from executor.models import QueryResults, ColumnOrder
 
 
 def get_uuid_str(length: int = 32) -> str:
@@ -23,6 +23,7 @@ class Base(DeclarativeBase, MappedAsDataclass):
     type_annotation_map = {
         dict[str, Any]: JSONB,
         QueryResults: JSONB,
+        ColumnOrder: ARRAY(Text),
         list[str]: ARRAY(String),
     }
 
@@ -227,6 +228,7 @@ class ExecutionResult(Base):
         ForeignKey("execution_logs.id"), index=True
     )
     result: Mapped[QueryResults] = mapped_column()
+    column_order: Mapped[ColumnOrder] = mapped_column()
     created_at: Mapped[datetime] = mapped_column(insert_default=func.now(), init=False)
 
     # Relationships

--- a/backend/executor/models.py
+++ b/backend/executor/models.py
@@ -8,6 +8,7 @@ QueryTypeLiteral = Literal[
 
 QueryResults = list[dict[str, Any]]
 
+ColumnOrder = list[str]
 
 class QueryType(BaseModel):
     query_type: QueryTypeLiteral


### PR DESCRIPTION
Added column_order field in ExecutionResults which can be used to show the query results while maintaining the column order. In database it is a TEXT[] type field.