### PR TITLE
Fix column order on frontend (Revised) and don't reset saved query state

### DIFF
--- a/frontend/src/components/ChatTable.tsx
+++ b/frontend/src/components/ChatTable.tsx
@@ -13,7 +13,7 @@ export type ChatTableProps = {
 };
 
 const ChatTable = (props: ChatTableProps) => {
-  const { data, isLoading, columnOrder = Object.keys(data) } = props;
+  const { data, isLoading, columnOrder = Object.keys(data[0]) } = props;
 
   // Compute the column definitions based on the column order
   const colDefs = useMemo(() => {

--- a/frontend/src/components/ChatTable.tsx
+++ b/frontend/src/components/ChatTable.tsx
@@ -2,21 +2,25 @@ import { Text } from "@chakra-ui/react";
 import { AgGridReact } from "ag-grid-react";
 import { themeQuartz, colorSchemeDarkBlue, ColDef } from "ag-grid-community";
 import { AllCommunityModule, ModuleRegistry } from "ag-grid-community";
+import { useMemo } from "react";
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
-const ChatTable = ({
-  data,
-  isLoading,
-}: {
+export type ChatTableProps = {
   data: Record<string, unknown>[];
   isLoading?: boolean;
-}) => {
+  columnOrder?: string[];
+};
+
+const ChatTable = (props: ChatTableProps) => {
+  const { data, isLoading, columnOrder = Object.keys(data) } = props;
+
+  // Compute the column definitions based on the column order
+  const colDefs = useMemo<ColDef[]>(() => {
+    return columnOrder.map((columnName) => ({ field: columnName }));
+  }, [columnOrder]);
+
   const rowData = data;
-  const colDefs: ColDef[] = Object.keys(rowData[0]).map((key) => ({
-    field: key,
-    filter: true,
-  }));
   const defaultColDef: ColDef = {
     maxWidth: 400,
   };

--- a/frontend/src/components/ChatTable.tsx
+++ b/frontend/src/components/ChatTable.tsx
@@ -16,8 +16,11 @@ const ChatTable = (props: ChatTableProps) => {
   const { data, isLoading, columnOrder = Object.keys(data) } = props;
 
   // Compute the column definitions based on the column order
-  const colDefs = useMemo<ColDef[]>(() => {
-    return columnOrder.map((columnName) => ({ field: columnName }));
+  const colDefs = useMemo(() => {
+    return columnOrder.map<ColDef>((columnName) => ({
+      field: columnName,
+      filter: true,
+    }));
   }, [columnOrder]);
 
   const rowData = data;

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -95,14 +95,23 @@ const NavBar = ({
   };
 
   const handleSavedQuery = (query: SavedQuery) => {
-    setSavedQueryTableData([]);
+    const destination = `${baseUrl}/saved/${query.sql_query_id}`;
+    // Return if the current path is already the same
+    if (window.location.pathname === destination) {
+      return;
+    }
+
+    // Update the state with the saved query data
     setId(query.sql_query_id);
     setSavedQueryData({
       name: query.name,
       description: query.description,
       sql_query_id: query.sql_query_id,
     });
-    navigate(`${baseUrl}/saved/${query.sql_query_id}`);
+    setSavedQueryTableData([]);
+
+    // Navigate to the saved query page
+    navigate(destination);
   };
 
   return (

--- a/frontend/src/components/NavBar/useNavBar.tsx
+++ b/frontend/src/components/NavBar/useNavBar.tsx
@@ -26,6 +26,7 @@ export type ExecutionLog = {
 export type ExecutionResponse = {
   execution_log: ExecutionLog;
   result?: Record<string, unknown>[];
+  column_order?: string[];
 };
 
 const useNavBar = (name?: string, description?: string) => {

--- a/frontend/src/components/SavedQuery/index.tsx
+++ b/frontend/src/components/SavedQuery/index.tsx
@@ -200,7 +200,7 @@ const SavedQuery = ({
           </Box>
         )}
         {
-          lastExecutedAt && (<span></span>)
+          lastExecutedAt && <span></span>
           //  <Text fontSize="sm" color="gray.300" fontStyle="italic">
           //    <strong>Last Updated At: </strong>
           //    {new Date(lastExecutedAt).toLocaleString(undefined, {
@@ -265,7 +265,11 @@ const SavedQuery = ({
         )}
         {savedQueryTableData.length > 0 && (
           <Box width="100%">
-            <ChatTable data={savedQueryTableData} isLoading={isFetching} />
+            <ChatTable
+              data={savedQueryTableData}
+              isLoading={isFetching}
+              columnOrder={executionResponse?.column_order}
+            />
           </Box>
         )}
       </VStack>


### PR DESCRIPTION
This PR makes the following changes:

- Compute the column definitions using the column_order obtained from backend. If no order is provided, use Object.keys(results) to get the default order.

- Fix the issue where clicking on the current saved query from the side nav resets the table 

