### PR TITLE
fix: return the column order as empty array incase resulted table data is empty array

### DIFF
--- a/frontend/src/components/ChatTable.tsx
+++ b/frontend/src/components/ChatTable.tsx
@@ -13,7 +13,8 @@ export type ChatTableProps = {
 };
 
 const ChatTable = (props: ChatTableProps) => {
-  const { data, isLoading, columnOrder = Object.keys(data[0]) } = props;
+  const { data, isLoading } = props;
+  const columnOrder = props.columnOrder ?? (data.length > 0 ? Object.keys(data[0]) : []);
 
   // Compute the column definitions based on the column order
   const colDefs = useMemo(() => {


### PR DESCRIPTION
fix: return the column order as empty array incase resulted table data is empty array while inferring column order from resulted table data(list of objects)