### PR TITLE
feat: added Add Query page for static and dynamic queries

### DIFF
--- a/backend/db/db_queries.py
+++ b/backend/db/db_queries.py
@@ -680,7 +680,7 @@ def share_query_to_users(
         raise
 
 def add_new_query(
-    db_session: Session, query_data: Any, user_id: str
+    db_session: Session, query_data: Any, params_data: Any, user_id: str
 ) -> str:
     try:
         sql_query = SqlQuery(
@@ -697,6 +697,10 @@ def add_new_query(
                 raise AddQueryError("Query ID already exists")
         else:
             sql_query.sqid = get_uuid_str()
+
+        if query_data['query_type'] == 'dynamic':
+            sql_query.query_type = 'dynamic'
+            sql_query.query_params = params_data
 
         db_session.add(sql_query)
 

--- a/backend/db/db_queries.py
+++ b/backend/db/db_queries.py
@@ -42,6 +42,9 @@ class ChatHistoryResponse(BaseModel):
     message: Optional[str] = None
     execution_id: Optional[int] = None
 
+class AddQueryError(Exception):
+    pass
+
 
 def get_or_create_user(
     db_session: Session,
@@ -624,6 +627,7 @@ def get_type_of_query(
         logger.error(f"Error getting query type: {e} ")
         return None
 
+
 def get_dynamic_query_params(
     db_session: Session, query_id: str,
 ) -> QueryParameterForm:
@@ -641,6 +645,7 @@ def get_dynamic_query_params(
         logger.error(f"Error getting query params: {e}")
         return []
 
+
 def share_query_to_users(
     db_session: Session, query_id: str, user_emails: list[str]
 ) -> Optional[SavedQuery]:
@@ -648,7 +653,7 @@ def share_query_to_users(
         saved_query = db_session.query(SavedQuery).filter_by(sqid=query_id).first()
         if not saved_query:
             raise Exception("Query not found")
-        
+
         name = saved_query.name
         description = saved_query.description
 
@@ -673,6 +678,63 @@ def share_query_to_users(
     except Exception as e:
         logger.error(f"Error adding saved queries: {e}")
         raise
+
+def add_new_query(
+    db_session: Session, query_data: Any, user_id: str
+) -> str:
+    try:
+        sql_query = SqlQuery(
+            sqlquery=query_data['query'],
+            database_used='karya_db',
+            user_id=user_id,
+        )
+        if query_data['query_id']:
+            query_id = db_session.query(SqlQuery.sqid).filter_by(
+                sqid=query_data['query_id']).scalar()
+            if not query_id:
+                sql_query.sqid = query_data['query_id']
+            else:
+                raise AddQueryError("Query ID already exists")
+        else:
+            sql_query.sqid = get_uuid_str()
+
+        db_session.add(sql_query)
+
+        saved_query = SavedQuery(
+            user_id=user_id,
+            name=query_data['query_name'],
+            description=query_data['query_description'],
+            sqid=sql_query.sqid
+        )
+        db_session.add(saved_query)
+
+        for email in query_data['user_emails']:
+            user_ids = [row[0] for row in db_session.query(User.user_id)
+                .filter_by(email=email).all()]
+            if not user_ids:
+                raise AddQueryError("Users not found")
+            for user_id in user_ids:
+                saved_query = SavedQuery(
+                    user_id=user_id,
+                    name=query_data['query_name'],
+                    description=query_data['query_description'],
+                    sqid=sql_query.sqid
+                )
+                db_session.add(saved_query)
+
+        db_session.commit()
+        return sql_query.sqid
+
+    except AddQueryError as e:
+        db_session.rollback()
+        logger.error(f"Error adding new query: {e}")
+        raise
+
+    except Exception as e:
+        db_session.rollback()
+        logger.error(f"Error adding new query: {e}")
+        raise
+
 
 def get_all_user_info(db_session: Session) -> List[User]:
     """

--- a/backend/server.py
+++ b/backend/server.py
@@ -580,7 +580,7 @@ async def add_query(
     logger.info(f"Adding new query, requested by user: {user_info.user_id}")
     try:
         body = await request.json()
-        response = add_new_query(db, body['query_data'], user_info.user_id)
+        response = add_new_query(db, body['query_data'], body['params_data'], user_info.user_id)
         return response
     except AddQueryError as e:
         logger.error(f"Error adding new query: {e}")

--- a/backend/server.py
+++ b/backend/server.py
@@ -31,6 +31,7 @@ from controllers.sql_response import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from db.db_queries import (
+    AddQueryError,
     ChatHistoryResponse,
     SavedQueriesResponse,
     UserSessionsResponse,
@@ -41,6 +42,7 @@ from db.db_queries import (
     get_type_of_query,
     get_recent_execution_for_query,
     get_recent_execution_for_query_id,
+    add_new_query,
 )
 from db.db_queries import (
     get_all_user_info,
@@ -552,7 +554,7 @@ async def share_query(
     """
     logger.info(f"Share query {query_id} requested by: {user_info.user_id}")
 
-    if user_info.role != "SUPER_ADMIN" and user_info.role != "ADMIN":
+    if user_info.role not in ["SUPER_ADMIN", "ADMIN", "COORDINATOR"]:
         raise HTTPException(status_code=403,
                             detail="You are not authorized to share this query")
     try:
@@ -562,5 +564,29 @@ async def share_query(
         return {"detail": "Query shared successfully"}
     except:
         raise HTTPException(status_code=500, detail="Failed to share query")
+    finally:
+        db.close()
+
+
+@app.post("/add_query")
+async def add_query(
+    request: Request,
+    db: Annotated[Session, Depends(get_db_session_from_request)],
+    user_info: Annotated[AuthenticatedUserInfo, Depends(get_authenticated_user_info)],
+):
+    """
+    Endpoint to add a new query and save it for the user
+    """
+    logger.info(f"Adding new query, requested by user: {user_info.user_id}")
+    try:
+        body = await request.json()
+        response = add_new_query(db, body['query_data'], user_info.user_id)
+        return response
+    except AddQueryError as e:
+        logger.error(f"Error adding new query: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to add query: {e}")
+    except Exception as e:
+        logger.error(f"Error adding new query: {e}")
+        raise HTTPException(status_code=500, detail="Failed to add query")
     finally:
         db.close()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,10 @@ function App() {
             path={`${baseUrl}/saved/:savedId`}
             element={<CheckUserAuth forComponent={<RootLayout />} />}
           />
+          <Route
+            path={`${baseUrl}/addquery`}
+            element={<CheckUserAuth forComponent={<RootLayout />} />}
+          />
         </Routes>
       </Router>
     </ErrorBoundary>

--- a/frontend/src/components/AddQuery/dynamicParamForm.tsx
+++ b/frontend/src/components/AddQuery/dynamicParamForm.tsx
@@ -1,0 +1,154 @@
+import {
+  VStack,
+  Box,
+  Button,
+  HStack,
+  Text,
+} from "@chakra-ui/react";
+import { useForm } from "src/helpers/parameter-renderer/hooks";
+import { ChakraFormRenderer } from "src/helpers/parameter-renderer/backends";
+import { ParameterArray, ParameterForm } from "src/helpers/parameter-spec/src/Index";
+import { useEffect, useMemo, useState } from "react";
+import { buildDynamicParamForm, getTypeSpecificParams } from "./formSpec";
+import { QueryForm } from "./formSpec";
+import { StoredDynamicParam } from "./formSpec";
+
+type DynamicParamFormProps = {
+  addedParamsList: StoredDynamicParam[]
+  setAddedParamsList: React.Dispatch<React.SetStateAction<StoredDynamicParam[]>>
+}
+
+const DynamicParamForm = ({
+  addedParamsList,
+  setAddedParamsList
+}: DynamicParamFormProps) => {
+
+  const [typeSpecificParams, setTypeSpecificParams] =
+    useState<ParameterArray<QueryForm>>([]);
+  const dynamicFormParameter = useMemo((): ParameterForm<QueryForm> =>
+    buildDynamicParamForm(typeSpecificParams), [typeSpecificParams]
+  );
+  const paramFormControl = useForm({
+    parameters: dynamicFormParameter,
+  });
+
+  useEffect(() => {
+    const selectedType = paramFormControl.ctx.form.type;
+    setTypeSpecificParams(getTypeSpecificParams(selectedType));
+  }, [paramFormControl.ctx.form.type]);
+
+  const handleAdd = async () => {
+    const paramData = paramFormControl.ctx.form;
+    const newParam: StoredDynamicParam = {
+      _internalId: `param-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      id: paramData.id || "id",
+      label: paramData.label,
+      type: paramData.type,
+      initial: paramData[`initial_${paramData.type}`],
+      list: Object.fromEntries(
+        (paramData[`list_${paramData.type}`] || []).map((item: string) => [item, item])
+      ) || {},
+    };
+    setAddedParamsList((prev) => [...prev, newParam]);
+  };
+
+  const handleDeleteParam = (_internalId: string) => {
+    setAddedParamsList(
+      (prev) => prev
+        .filter((param) => param._internalId !== _internalId)
+    );
+  };
+
+  return (
+    <VStack w="100%" align="start" mt={6}>
+      <Box w="100%" fontSize="2xl" fontWeight="bold" textAlign="left" mb={4}>
+        Added Dynamic Parameters
+      </Box>
+
+      {addedParamsList.length === 0 ? (
+        <Text color="gray.500" mb={4}>No dynamic parameters added yet.</Text>
+      ) : (
+        <VStack
+          w="100%"
+          align="start"
+          spacing={3}
+          mb={6}
+          border="1px"
+          borderColor="gray.700"
+          p={4}
+          borderRadius="md"
+        >
+          {addedParamsList.map((param, index) => (
+            <HStack
+              key={param._internalId}
+              w="100%"
+              justifyContent="space-between"
+              alignItems="center"
+              p={2}
+              bg="gray.800"
+              borderRadius="md"
+            >
+              <Box>
+                <Text fontWeight="bold" color="white">
+                  {index + 1}. {param.label || param.id}
+                </Text>
+                <VStack
+                  align="start"
+                  spacing={0}
+                  color="gray.400"
+                >
+                  <Text as="span" fontWeight="semibold">
+                    Id: {param.id}
+                  </Text>
+
+                  <Text as="span" fontWeight="semibold">
+                    Type: {param.type}
+                  </Text>
+
+                  {(param.initial !== undefined && param.initial !== null) && (
+                    <Text as="span" fontWeight="semibold">
+                      Initial: {
+                        Array.isArray(param.initial) ?
+                          param.initial.join(', ') : String(param.initial)
+                      }
+                    </Text>
+                  )}
+
+                  {param.list && typeof param.list === 'object' &&
+                    Object.keys(param.list).length > 0 && (
+                      <Text as="span" fontWeight="semibold">
+                        Options: {`${Object.keys(param.list).join(', ')}`}
+                      </Text>
+                    )}
+                </VStack>
+              </Box>
+              <Button
+                size="sm"
+                colorScheme="red"
+                variant="outline"
+                onClick={() => handleDeleteParam(param._internalId)}
+              >
+                Delete
+              </Button>
+            </HStack>
+          ))}
+        </VStack>
+      )}
+
+      <ChakraFormRenderer ctx={paramFormControl.ctx} />
+      <Button
+        justifyContent={"space-between"}
+        marginBottom={12}
+        gap={2}
+        color="gray.400"
+        bg="gray.700"
+        _hover={{ bg: "gray.600", color: "gray.400" }}
+        onClick={handleAdd}
+      >
+        Add
+      </Button>
+    </VStack>
+  )
+};
+
+export default DynamicParamForm;

--- a/frontend/src/components/AddQuery/formSpec.ts
+++ b/frontend/src/components/AddQuery/formSpec.ts
@@ -1,0 +1,186 @@
+import { ParameterArray, ParameterForm } from "src/helpers/parameter-spec/src/Index";
+
+export type QueryForm = {
+  id: string;
+  name: string;
+  initial: any;
+  list: [any];
+  [key: string]: any;
+};
+
+export type StoredDynamicParam = {
+  _internalId: string;
+  id: string;
+  label: string;
+  type: string;
+  initial: any;
+  list?: {};
+};
+
+export const buildQueryForm = (): ParameterForm<QueryForm> => [{
+  label: "",
+  required: false,
+  parameters: [
+    {
+      id: "query",
+      label: "Query",
+      required: true,
+      placeholder: "SQL Query",
+      type: "string",
+      initial: "",
+      extraProps: { width: "700px" },
+      long: true,
+    },{
+      id: "query_name",
+      label: "Query Name",
+      required: true,
+      placeholder: "Name",
+      type: "string",
+      initial: "",
+    },{
+      id: "query_description",
+      label: "Query Description",
+      placeholder: "A short description for the query",
+      required: true,
+      type: "string",
+      initial: "",
+      long: true,
+    },{
+      id: "query_id",
+      label: "Query Id (Optional)",
+      placeholder: "Query Id",
+      required: false,
+      type: "string",
+      extraProps: { width: "400px" },
+      initial: "",
+    },{
+      id: "query_type",
+      label: "Query Type",
+      required: false,
+      type: "enum",
+      list: { static: "static", dynamic: "dynamic" },
+      initial: "static",
+    },{
+      id: "user_emails",
+      label: "User Emails to share with (comma-separated)",
+      required: false,
+      type: "list",
+      initial: [],
+      extraProps: { width: "250px" },
+      delimiters: [","],
+    }
+  ]
+}];
+
+export const buildDynamicParamForm = (
+  typeSpecificParams: ParameterArray<QueryForm>
+): ParameterForm<QueryForm> => [{
+  label: "",
+  required: false,
+  parameters: [
+    {
+      id: "id",
+      label: "Parameter Id",
+      required: true,
+      placeholder: "Id should be the same as in the query",
+      type: "string",
+      extraProps: { width: "300px" },
+    },{
+      id: "label",
+      label: "Parameter Label",
+      required: true,
+      placeholder: "Parameter Label",
+      type: "string",
+      extraProps: { width: "300px" },
+    },{
+      id: "type",
+      label: "Parameter Type",
+      required: true,
+      type: "enum",
+      initial: "int",
+      list: {
+        "int": "int",
+        "float": "float",
+        "string": "string",
+        "list": "list",
+        "boolean": "boolean",
+        "enum": "enum",
+        "enum_multi": "enum_multi",
+        "date": "date",
+        "time": "time",
+        "datetime-local": "datetime-local",
+      },
+    },
+    ...typeSpecificParams
+  ]
+}];
+
+export const getTypeSpecificParams = (
+  selectedType: string
+): ParameterArray<QueryForm> => {
+  switch (selectedType) {
+    case 'int':
+    case 'float':
+    case 'string':
+    case 'date':
+    case 'time':
+    case 'datetime-local':
+      return [
+        {
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: selectedType,
+        }
+      ] as ParameterArray<QueryForm>;
+    case 'enum':
+      return [
+        {
+          id: `list_${selectedType}`,
+          label: "Enum Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        },{
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: "string",
+        }
+      ];
+    case 'enum_multi':
+      return [
+        {
+          id: `list_${selectedType}`,
+          label: "Enum Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        },{
+          id: `initial_${selectedType}`,
+          label: "Initial Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        }
+      ];
+    case 'boolean':
+      return [{
+        id: `initial_${selectedType}`,
+        label: "Initial Value",
+        required: true,
+        type: "enum",
+        list: { "true": "true", "false": "false" },
+      }];
+    case 'list':
+      return [{
+        id: `initial_${selectedType}`,
+        label: "Initial List Values (comma-separated)",
+        required: true,
+        type: "list",
+        delimiters: [","],
+      }];
+    default:
+      return [];
+  }
+};

--- a/frontend/src/components/AddQuery/index.tsx
+++ b/frontend/src/components/AddQuery/index.tsx
@@ -4,36 +4,19 @@ import {
   Box,
   Button,
   useToast,
-  HStack,
-  Text,
 } from "@chakra-ui/react";
 import { GoSidebarCollapse } from "react-icons/go";
 import { useForm } from "src/helpers/parameter-renderer/hooks";
 import { ChakraFormRenderer } from "src/helpers/parameter-renderer/backends";
-import { ParameterArray, ParameterForm } from "src/helpers/parameter-spec/src/Index";
-import { useEffect, useMemo, useState } from "react";
+import { ParameterForm } from "src/helpers/parameter-spec/src/Index";
+import { useMemo, useState } from "react";
 import { BACKEND_URL } from "src/config";
+import { buildQueryForm, QueryForm, StoredDynamicParam } from "./formSpec";
+import DynamicParamForm from "./dynamicParamForm";
 
 type AddQueryProps = {
   navOpen: boolean;
   setNavOpen: (arg: (prev: boolean) => boolean) => void;
-};
-
-type QueryForm = {
-  id: string;
-  name: string;
-  initial: any;
-  list: [any];
-  [key: string]: any;
-};
-
-type StoredDynamicParam = {
-  _internalId: string;
-  id: string;
-  label: string;
-  type: string;
-  initial: any;
-  list?: {};
 };
 
 const AddQuery = ({
@@ -42,219 +25,11 @@ const AddQuery = ({
 }: AddQueryProps) => {
 
   const toast = useToast({ position: "bottom-right" });
-  const formParameters = useMemo((): ParameterForm<QueryForm> => [{
-    label: "",
-    required: false,
-    parameters: [
-      {
-        id: "query",
-        label: "Query",
-        required: true,
-        placeholder: "SQL Query",
-        type: "string",
-        initial: "",
-        extraProps: { width: "700px" },
-        long: true,
-      },{
-        id: "query_name",
-        label: "Query Name",
-        required: true,
-        placeholder: "Name",
-        type: "string",
-        initial: "",
-      },{
-        id: "query_description",
-        label: "Query Description",
-        placeholder: "A short description for the query",
-        required: true,
-        type: "string",
-        initial: "",
-        long: true,
-      },{
-        id: "query_id",
-        label: "Query Id (Optional)",
-        placeholder: "Query Id",
-        required: false,
-        type: "string",
-        extraProps: { width: "400px" },
-        initial: "",
-      },{
-        id: "query_type",
-        label: "Query Type",
-        required: false,
-        type: "enum",
-        list: { static: "static", dynamic: "dynamic" },
-        initial: "static",
-      },{
-        id: "user_emails",
-        label: "User Emails to share with (comma-separated)",
-        required: false,
-        type: "list",
-        initial: [],
-        extraProps: { width: "250px" },
-        delimiters: [","],
-      }
-    ]
-  }], []);
-
+  const [addedParamsList, setAddedParamsList] = useState<StoredDynamicParam[]>([]);
+  const formParameters = useMemo((): ParameterForm<QueryForm> => buildQueryForm(), []);
   const formControl = useForm({
     parameters: formParameters,
   });
-
-  const [addedParamsList, setAddedParamsList] = useState<StoredDynamicParam[]>([]);
-
-  const [typeSpecificParams, setTypeSpecificParams] = useState<ParameterArray<QueryForm>>([]);
-
-  const dynamicFormParameter = useMemo((): ParameterForm<QueryForm> => [{
-    label: "",
-    required: false,
-    parameters: [
-      {
-        id: "id",
-        label: "Parameter Id",
-        required: true,
-        placeholder: "Id should be the same as in the query",
-        type: "string",
-        extraProps: { width: "300px" },
-      },{
-        id: "label",
-        label: "Parameter Label",
-        required: true,
-        placeholder: "Parameter Label",
-        type: "string",
-        extraProps: { width: "300px" },
-      },{
-        id: "type",
-        label: "Parameter Type",
-        required: true,
-        type: "enum",
-        initial: "int",
-        list: {
-          "int": "int",
-          "float": "float",
-          "string": "string",
-          "list": "list",
-          "boolean": "boolean",
-          "enum": "enum",
-          "enum_multi": "enum_multi",
-          "date": "date",
-          "time": "time",
-          "datetime-local": "datetime-local",
-        },
-      },
-      ...typeSpecificParams
-    ]
-  }], [typeSpecificParams]);
-
-  const paramFormControl = useForm({
-    parameters: dynamicFormParameter,
-  });
-
-  useEffect(() => {
-    const selectedType = paramFormControl.ctx.form.type;
-    if (selectedType === 'int' || selectedType === 'float') {
-      setTypeSpecificParams([
-        {
-          id: `initial_${selectedType}`,
-          label: "Initial Value",
-          required: true,
-          type: selectedType,
-        }
-      ]);
-    } else if (
-      selectedType === 'string' ||
-      selectedType === 'date' ||
-      selectedType === 'time' ||
-      selectedType === 'datetime-local'
-    ) {
-      setTypeSpecificParams([
-        {
-          id: `initial_${selectedType}`,
-          label: "Initial Value",
-          required: true,
-          type: selectedType,
-        }
-      ]);
-    } else if (selectedType === 'enum') {
-      setTypeSpecificParams([
-        {
-          id: `list_${selectedType}`,
-          label: "Enum Options (comma-separated)",
-          required: true,
-          type: "list",
-          delimiters: [","],
-        },{
-          id: `initial_${selectedType}`,
-          label: "Initial Value",
-          required: true,
-          type: "string",
-        }
-      ]);
-    } else if (selectedType === 'enum_multi') {
-      setTypeSpecificParams([
-        {
-          id: `list_${selectedType}`,
-          label: "Enum Options (comma-separated)",
-          required: true,
-          type: "list",
-          delimiters: [","],
-        },{
-          id: `initial_${selectedType}`,
-          label: "Initial Options (comma-separated)",
-          required: true,
-          type: "list",
-          delimiters: [","],
-        }
-      ]);
-    } else if (selectedType === 'boolean') {
-      setTypeSpecificParams([
-        {
-          id: `initial_${selectedType}`,
-          label: "Initial Value",
-          required: true,
-          type: "enum",
-          list: {"true": "true", "false": "false"},
-        }
-      ]);
-    } else if (selectedType === 'list') {
-      setTypeSpecificParams([
-        {
-          id: `initial_${selectedType}`,
-          label: "Initial List Values (comma-separated)",
-          required: true,
-          type: "list",
-          delimiters: [","],
-        }
-      ]);
-    }
-    else {
-      setTypeSpecificParams([]);
-    }
-
-  }, [paramFormControl.ctx.form.type]);
-
-  const handleAdd = async () => {
-    const paramData = paramFormControl.ctx.form;
-    const newParam: StoredDynamicParam = {
-      _internalId: `param-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-      id: paramData.id || "id",
-      label: paramData.label,
-      type: paramData.type,
-      initial: paramData[`initial_${paramData.type}`],
-      list: Object.fromEntries(
-        (paramData[`list_${paramData.type}`] || [])
-          .map((item: string) => [item, item])
-      ) || {},
-    };
-    setAddedParamsList((prev) => [...prev, newParam]);
-  };
-
-  const handleDeleteParam = (_internalId: string) => {
-    setAddedParamsList(
-      (prev) => prev
-        .filter((param) => param._internalId !== _internalId)
-    );
-  };
 
   const handleSubmit = async () => {
     try {
@@ -281,7 +56,6 @@ const AddQuery = ({
           status: "success",
         });
         setAddedParamsList([]);
-        setTypeSpecificParams([]);
       } else {
         const errorData = await response.json();
         toast({
@@ -294,107 +68,6 @@ const AddQuery = ({
     } catch (error) {
       console.error("Error adding query:", error);
     }
-  }
-
-  const renderAddedParams = () => {
-    return addedParamsList.length === 0 ? (
-      <Text color="gray.500" mb={4}>No dynamic parameters added yet.</Text>
-    ) : (
-      <VStack
-        w="100%"
-        align="start"
-        spacing={3}
-        mb={6}
-        border="1px"
-        borderColor="gray.700"
-        p={4}
-        borderRadius="md"
-      >
-        {addedParamsList.map((param, index) => (
-          <HStack
-            key={param._internalId}
-            w="100%"
-            justifyContent="space-between"
-            alignItems="center"
-            p={2}
-            bg="gray.800"
-            borderRadius="md"
-          >
-            <Box>
-              <Text fontWeight="bold" color="white">
-                {index + 1}. {param.label || param.id}
-              </Text>
-              <VStack
-                align="start"
-                spacing={0}
-                color="gray.400"
-              >
-                <Text as="span" fontWeight="semibold">
-                  Id: {param.id}
-                </Text>
-
-                <Text as="span" fontWeight="semibold">
-                  Type: {param.type}
-                </Text>
-
-                {(param.initial !== undefined && param.initial !== null) && (
-                  <Text as="span" fontWeight="semibold">
-                    Initial: {
-                      Array.isArray(param.initial) ?
-                        param.initial.join(', ') : String(param.initial)
-                    }
-                  </Text>
-                )}
-
-                {param.list && typeof param.list === 'object' &&
-                  Object.keys(param.list).length > 0 && (
-                    <Text as="span" fontWeight="semibold">
-                      Options: {`${Object.keys(param.list).join(', ')}`}
-                    </Text>
-                  )}
-              </VStack>
-            </Box>
-            <Button
-              size="sm"
-              colorScheme="red"
-              variant="outline"
-              onClick={() => handleDeleteParam(param._internalId)}
-            >
-              Delete
-            </Button>
-          </HStack>
-        ))}
-      </VStack>
-    )
-  }
-
-  const renderParamForm = () => {
-    if (formControl.ctx.form.query_type === 'static') {
-      return null;
-    }
-
-    return (
-      <VStack w="100%" align="start" mt={6}>
-        <Box w="100%" fontSize="2xl" fontWeight="bold" textAlign="left" mb={4}>
-          Added Dynamic Parameters
-        </Box>
-
-        {renderAddedParams()}
-
-        <ChakraFormRenderer ctx={paramFormControl.ctx} />
-        <Button
-          justifyContent={"space-between"}
-          marginBottom={12}
-          gap={2}
-          color="gray.400"
-          bg="gray.700"
-          _hover={{ bg: "gray.600", color: "gray.400" }}
-          onClick={handleAdd}
-        >
-          Add
-        </Button>
-      </VStack>
-    )
   }
 
   return (
@@ -432,7 +105,12 @@ const AddQuery = ({
           Add Query
         </Box>
         <ChakraFormRenderer ctx={formControl.ctx} />
-        {renderParamForm()}
+        {formControl.ctx.form.query_type === 'dynamic' &&
+          <DynamicParamForm
+            addedParamsList={addedParamsList}
+            setAddedParamsList={setAddedParamsList}
+          />
+        }
         <Box w="100%">
           <Button
             justifyContent={"space-between"}

--- a/frontend/src/components/AddQuery/index.tsx
+++ b/frontend/src/components/AddQuery/index.tsx
@@ -1,0 +1,173 @@
+import {
+  VStack,
+  Icon,
+  Box,
+  Button,
+  useToast,
+} from "@chakra-ui/react";
+import { GoSidebarCollapse } from "react-icons/go";
+import { useForm } from "src/helpers/parameter-renderer/hooks";
+import { ChakraFormRenderer } from "src/helpers/parameter-renderer/backends";
+import { ParameterForm } from "src/helpers/parameter-spec/src/Index";
+import { useMemo } from "react";
+import { BACKEND_URL } from "src/config";
+
+type AddQueryProps = {
+  navOpen: boolean;
+  setNavOpen: (arg: (prev: boolean) => boolean) => void;
+};
+
+type QueryForm = {
+  id: string;
+  name: string;
+  default: any;
+  list: [any];
+  [key: string]: any;
+};
+
+const AddQuery = ({
+  navOpen,
+  setNavOpen,
+}: AddQueryProps) => {
+  
+  const toast = useToast({ position: "bottom-right" });
+  const formParameters = useMemo((): ParameterForm<QueryForm> => [{
+    label: "",
+    required: false,
+    parameters: [
+      {
+        id: "query",
+        label: "Query",
+        required: true,
+        placeholder: "SQL Query",
+        type: "string",
+        initial: "",
+        extraProps: {width: "700px"},
+        long: true,
+      },{
+        id: "query_name",
+        label: "Query Name",
+        required: true,
+        placeholder: "Name",
+        type: "string",
+        initial: "",
+      },{
+        id: "query_description",
+        label: "Query Description",
+        placeholder: "A short description for the query",
+        required: true,
+        type: "string",
+        initial: "",
+        long: true,
+      },{
+        id: "query_id",
+        label: "Query Id (Optional)",
+        placeholder: "Query Id",
+        required: false,
+        type: "string",
+        extraProps: {width: "400px"},
+        initial: "",
+      },{
+        id: "user_emails",
+        label: "User Emails to share with (comma-separated)",
+        required: false,
+        type: "list",
+        initial: [],
+        extraProps: {width: "250px"},
+        delimiters: [","],
+      }
+    ]
+  }], []);
+
+  const formControl = useForm({
+    parameters: formParameters,
+  });
+
+  const handleSubmit = async () => {
+    try {
+      const query_data = formControl.ctx.form;
+      const response = await fetch(
+        `${BACKEND_URL}/add_query`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            "query_data": query_data
+          }),
+          credentials: "include",
+        }
+      );
+
+      if (response.status == 200) {
+        toast({
+          title: "Query added successfully",
+          description: "The Query has been added and shared with the specified users",
+          status: "success",
+        });
+      } else {
+        const errorData = await response.json();
+        toast({
+          title: "Failed to add query",
+          description: errorData.detail ? errorData.detail :
+            "An unexpected error occurred",
+          status: "error",
+        });
+      }
+      
+    } catch (error) {
+      console.error("Error adding query:", error);
+    }
+  }
+
+  return (
+    <VStack
+      bg="gray.900"
+      align="start"
+      gap={6}
+      w="100%"
+      h="100%"
+      p={8}
+      color="white"
+      overflowY="auto"
+    >
+      {!navOpen && (
+        <Icon
+          as={GoSidebarCollapse}
+          stroke="gray.400"
+          strokeWidth={1}
+          fontSize="xl"
+          cursor="pointer"
+          onClick={() => setNavOpen((prev: boolean) => !prev)}
+          position="absolute"
+          top={5}
+          left={5}
+        />
+      )}
+      <VStack
+        w="full"
+        px={{ base: "2.5vw", xl: "5vw" }}
+        align="start"
+        gap={4}
+        color={"gray.400"}
+      >
+        <Box w="100%" fontSize="2xl" fontWeight="bold" textAlign="left">
+          Add Query
+        </Box>
+        <ChakraFormRenderer ctx={formControl.ctx} />
+        <Box w="100%">
+          <Button
+            justifyContent={"space-between"}
+            gap={2}
+            color="gray.400"
+            bg="gray.700"
+            _hover={{ bg: "gray.600", color: "gray.400" }}
+            onClick={handleSubmit}
+          >
+            Submit
+          </Button>
+        </Box>
+      </VStack>
+    </VStack>
+  );
+};
+
+export default AddQuery;

--- a/frontend/src/components/AddQuery/index.tsx
+++ b/frontend/src/components/AddQuery/index.tsx
@@ -4,12 +4,14 @@ import {
   Box,
   Button,
   useToast,
+  HStack,
+  Text,
 } from "@chakra-ui/react";
 import { GoSidebarCollapse } from "react-icons/go";
 import { useForm } from "src/helpers/parameter-renderer/hooks";
 import { ChakraFormRenderer } from "src/helpers/parameter-renderer/backends";
-import { ParameterForm } from "src/helpers/parameter-spec/src/Index";
-import { useMemo } from "react";
+import { ParameterArray, ParameterForm } from "src/helpers/parameter-spec/src/Index";
+import { useEffect, useMemo, useState } from "react";
 import { BACKEND_URL } from "src/config";
 
 type AddQueryProps = {
@@ -20,16 +22,25 @@ type AddQueryProps = {
 type QueryForm = {
   id: string;
   name: string;
-  default: any;
+  initial: any;
   list: [any];
   [key: string]: any;
+};
+
+type StoredDynamicParam = {
+  _internalId: string;
+  id: string;
+  label: string;
+  type: string;
+  initial: any;
+  list?: {};
 };
 
 const AddQuery = ({
   navOpen,
   setNavOpen,
 }: AddQueryProps) => {
-  
+
   const toast = useToast({ position: "bottom-right" });
   const formParameters = useMemo((): ParameterForm<QueryForm> => [{
     label: "",
@@ -42,7 +53,7 @@ const AddQuery = ({
         placeholder: "SQL Query",
         type: "string",
         initial: "",
-        extraProps: {width: "700px"},
+        extraProps: { width: "700px" },
         long: true,
       },{
         id: "query_name",
@@ -65,15 +76,22 @@ const AddQuery = ({
         placeholder: "Query Id",
         required: false,
         type: "string",
-        extraProps: {width: "400px"},
+        extraProps: { width: "400px" },
         initial: "",
+      },{
+        id: "query_type",
+        label: "Query Type",
+        required: false,
+        type: "enum",
+        list: { static: "static", dynamic: "dynamic" },
+        initial: "static",
       },{
         id: "user_emails",
         label: "User Emails to share with (comma-separated)",
         required: false,
         type: "list",
         initial: [],
-        extraProps: {width: "250px"},
+        extraProps: { width: "250px" },
         delimiters: [","],
       }
     ]
@@ -83,15 +101,174 @@ const AddQuery = ({
     parameters: formParameters,
   });
 
+  const [addedParamsList, setAddedParamsList] = useState<StoredDynamicParam[]>([]);
+
+  const [typeSpecificParams, setTypeSpecificParams] = useState<ParameterArray<QueryForm>>([]);
+
+  const dynamicFormParameter = useMemo((): ParameterForm<QueryForm> => [{
+    label: "",
+    required: false,
+    parameters: [
+      {
+        id: "id",
+        label: "Parameter Id",
+        required: true,
+        placeholder: "Id should be the same as in the query",
+        type: "string",
+        extraProps: { width: "300px" },
+      },{
+        id: "label",
+        label: "Parameter Label",
+        required: true,
+        placeholder: "Parameter Label",
+        type: "string",
+        extraProps: { width: "300px" },
+      },{
+        id: "type",
+        label: "Parameter Type",
+        required: true,
+        type: "enum",
+        initial: "int",
+        list: {
+          "int": "int",
+          "float": "float",
+          "string": "string",
+          "list": "list",
+          "boolean": "boolean",
+          "enum": "enum",
+          "enum_multi": "enum_multi",
+          "date": "date",
+          "time": "time",
+          "datetime-local": "datetime-local",
+        },
+      },
+      ...typeSpecificParams
+    ]
+  }], [typeSpecificParams]);
+
+  const paramFormControl = useForm({
+    parameters: dynamicFormParameter,
+  });
+
+  useEffect(() => {
+    const selectedType = paramFormControl.ctx.form.type;
+    if (selectedType === 'int' || selectedType === 'float') {
+      setTypeSpecificParams([
+        {
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: selectedType,
+        }
+      ]);
+    } else if (
+      selectedType === 'string' ||
+      selectedType === 'date' ||
+      selectedType === 'time' ||
+      selectedType === 'datetime-local'
+    ) {
+      setTypeSpecificParams([
+        {
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: selectedType,
+        }
+      ]);
+    } else if (selectedType === 'enum') {
+      setTypeSpecificParams([
+        {
+          id: `list_${selectedType}`,
+          label: "Enum Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        },{
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: "string",
+        }
+      ]);
+    } else if (selectedType === 'enum_multi') {
+      setTypeSpecificParams([
+        {
+          id: `list_${selectedType}`,
+          label: "Enum Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        },{
+          id: `initial_${selectedType}`,
+          label: "Initial Options (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        }
+      ]);
+    } else if (selectedType === 'boolean') {
+      setTypeSpecificParams([
+        {
+          id: `initial_${selectedType}`,
+          label: "Initial Value",
+          required: true,
+          type: "enum",
+          list: {"true": "true", "false": "false"},
+        }
+      ]);
+    } else if (selectedType === 'list') {
+      setTypeSpecificParams([
+        {
+          id: `initial_${selectedType}`,
+          label: "Initial List Values (comma-separated)",
+          required: true,
+          type: "list",
+          delimiters: [","],
+        }
+      ]);
+    }
+    else {
+      setTypeSpecificParams([]);
+    }
+
+  }, [paramFormControl.ctx.form.type]);
+
+  const handleAdd = async () => {
+    const paramData = paramFormControl.ctx.form;
+    const newParam: StoredDynamicParam = {
+      _internalId: `param-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      id: paramData.id || "id",
+      label: paramData.label,
+      type: paramData.type,
+      initial: paramData[`initial_${paramData.type}`],
+      list: Object.fromEntries(
+        (paramData[`list_${paramData.type}`] || [])
+          .map((item: string) => [item, item])
+      ) || {},
+    };
+    setAddedParamsList((prev) => [...prev, newParam]);
+  };
+
+  const handleDeleteParam = (_internalId: string) => {
+    setAddedParamsList(
+      (prev) => prev
+        .filter((param) => param._internalId !== _internalId)
+    );
+  };
+
   const handleSubmit = async () => {
     try {
       const query_data = formControl.ctx.form;
-      const response = await fetch(
-        `${BACKEND_URL}/add_query`,
-        {
+      const params_data = addedParamsList
+        .map(({ _internalId, ...rest }) => rest) || [];
+      const response = await fetch(`${BACKEND_URL}/add_query`, {
           method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
           body: JSON.stringify({
-            "query_data": query_data
+            "query_data": query_data,
+            "params_data": params_data
           }),
           credentials: "include",
         }
@@ -103,6 +280,8 @@ const AddQuery = ({
           description: "The Query has been added and shared with the specified users",
           status: "success",
         });
+        setAddedParamsList([]);
+        setTypeSpecificParams([]);
       } else {
         const errorData = await response.json();
         toast({
@@ -112,10 +291,110 @@ const AddQuery = ({
           status: "error",
         });
       }
-      
     } catch (error) {
       console.error("Error adding query:", error);
     }
+  }
+
+  const renderAddedParams = () => {
+    return addedParamsList.length === 0 ? (
+      <Text color="gray.500" mb={4}>No dynamic parameters added yet.</Text>
+    ) : (
+      <VStack
+        w="100%"
+        align="start"
+        spacing={3}
+        mb={6}
+        border="1px"
+        borderColor="gray.700"
+        p={4}
+        borderRadius="md"
+      >
+        {addedParamsList.map((param, index) => (
+          <HStack
+            key={param._internalId}
+            w="100%"
+            justifyContent="space-between"
+            alignItems="center"
+            p={2}
+            bg="gray.800"
+            borderRadius="md"
+          >
+            <Box>
+              <Text fontWeight="bold" color="white">
+                {index + 1}. {param.label || param.id}
+              </Text>
+              <VStack
+                align="start"
+                spacing={0}
+                color="gray.400"
+              >
+                <Text as="span" fontWeight="semibold">
+                  Id: {param.id}
+                </Text>
+
+                <Text as="span" fontWeight="semibold">
+                  Type: {param.type}
+                </Text>
+
+                {(param.initial !== undefined && param.initial !== null) && (
+                  <Text as="span" fontWeight="semibold">
+                    Initial: {
+                      Array.isArray(param.initial) ?
+                        param.initial.join(', ') : String(param.initial)
+                    }
+                  </Text>
+                )}
+
+                {param.list && typeof param.list === 'object' &&
+                  Object.keys(param.list).length > 0 && (
+                    <Text as="span" fontWeight="semibold">
+                      Options: {`${Object.keys(param.list).join(', ')}`}
+                    </Text>
+                  )}
+              </VStack>
+            </Box>
+            <Button
+              size="sm"
+              colorScheme="red"
+              variant="outline"
+              onClick={() => handleDeleteParam(param._internalId)}
+            >
+              Delete
+            </Button>
+          </HStack>
+        ))}
+      </VStack>
+    )
+  }
+
+  const renderParamForm = () => {
+    if (formControl.ctx.form.query_type === 'static') {
+      return null;
+    }
+
+    return (
+      <VStack w="100%" align="start" mt={6}>
+        <Box w="100%" fontSize="2xl" fontWeight="bold" textAlign="left" mb={4}>
+          Added Dynamic Parameters
+        </Box>
+
+        {renderAddedParams()}
+
+        <ChakraFormRenderer ctx={paramFormControl.ctx} />
+        <Button
+          justifyContent={"space-between"}
+          marginBottom={12}
+          gap={2}
+          color="gray.400"
+          bg="gray.700"
+          _hover={{ bg: "gray.600", color: "gray.400" }}
+          onClick={handleAdd}
+        >
+          Add
+        </Button>
+      </VStack>
+    )
   }
 
   return (
@@ -153,6 +432,7 @@ const AddQuery = ({
           Add Query
         </Box>
         <ChakraFormRenderer ctx={formControl.ctx} />
+        {renderParamForm()}
         <Box w="100%">
           <Button
             justifyContent={"space-between"}

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -12,6 +12,7 @@ import {
   AccordionPanel,
   AccordionIcon,
 } from "@chakra-ui/react";
+import { IoIosAdd } from "react-icons/io";
 import { GoSidebarExpand } from "react-icons/go";
 import { useNavigate } from "react-router-dom";
 import CFImage from "../CloudflareImage";
@@ -114,6 +115,10 @@ const NavBar = ({
     navigate(destination);
   };
 
+  const handleAddQuery = () => {
+    navigate(`${baseUrl}/addquery`);
+  }
+
   return (
     <VStack
       bg="#2a2d3d"
@@ -153,6 +158,19 @@ const NavBar = ({
         />
       </HStack>
       <Accordion allowToggle w="full" color="gray.400" flex={1}>
+        <AccordionItem border={"none"}>
+          <AccordionButton onClick={() => handleAddQuery()}>
+            <Icon
+              as={IoIosAdd}
+              stroke="gray.400"
+              strokeWidth={4}
+              fontSize="xl"
+            />
+            <Box flex="1" textAlign="left" fontWeight="bold" pl={2}>
+              Add Query
+            </Box>
+          </AccordionButton>
+        </AccordionItem>
         <AccordionItem border={"none"}>
           <AccordionButton>
             <AccordionIcon />

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -7,6 +7,7 @@ import useNavBar from "../components/NavBar/useNavBar";
 import SavedQuery from "../components/SavedQuery";
 import { SavedQueryContext } from "../components/NavBar/utils";
 import Error from "../components/Error";
+import AddQuery from "src/components/AddQuery";
 
 const RootLayout = () => {
   const {
@@ -70,6 +71,8 @@ const RootLayout = () => {
               savedQueryTableData={savedQueryTableData}
               setSavedQueryTableData={setSavedQueryTableData}
             />
+          ) : window.location.pathname === "/nlq/addquery" ? (
+            <AddQuery navOpen={navOpen} setNavOpen={setNavOpen} />
           ) : (
             <ChatBot
               messages={messages}


### PR DESCRIPTION
Added an Add Query Page, to insert queries directly from the dashboard.
Users needs to provide the SQL query, name and description. Users can also provide a query_id (needs to be unique) and a list of users to share the query with.
For dynamic queries, users need to provide a set of params that will be used while executing the query.